### PR TITLE
Create realloc_function_in_C.c

### DIFF
--- a/c/Dynamic_memory_allocation_in_C/realloc_function_in_C.c
+++ b/c/Dynamic_memory_allocation_in_C/realloc_function_in_C.c
@@ -1,0 +1,6 @@
+// realloc() function in C
+// If memory is not sufficient for malloc() or calloc(), you can reallocate the memory by realloc() function. In short, it changes the memory size.
+
+ptr=realloc(ptr, new-size) 
+
+  


### PR DESCRIPTION
The memory occupied by malloc() or calloc() functions must be released by calling free() function. Otherwise, it will consume memory until program exit.

Let's see the syntax of free() function