### PR TITLE
Create free_function_in_C.c

### DIFF
--- a/c/Dynamic_memory_allocation_in_C/free_function_in_C.c
+++ b/c/Dynamic_memory_allocation_in_C/free_function_in_C.c
@@ -1,0 +1,6 @@
+// free() function in C
+// The memory occupied by malloc() or calloc() functions must be released by calling free() function. Otherwise, it will consume memory until program exit.
+//Let's see the syntax of free() function.
+
+
+free(ptr) 


### PR DESCRIPTION
The memory occupied by malloc() or calloc() functions must be released by calling free() function. Otherwise, it will consume memory until program exit.